### PR TITLE
Remove fcrepo4 reference in github template.'

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,4 +35,4 @@ Example:
 * Could this change impact execution of existing code?
 
 # Interested parties
-Tag (@ mention) interested parties or, if unsure, @fcrepo4/committers
+Tag (@ mention) interested parties or, if unsure, @fcrepo/committers


### PR DESCRIPTION


# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
